### PR TITLE
fix: disable resize properties in the textarea inputs

### DIFF
--- a/src/components/CardTransfer.vue
+++ b/src/components/CardTransfer.vue
@@ -91,7 +91,7 @@
       <!-- card from -->
       <div class="w-1/2 border-r-[1px] border-gray-200 h-[200px]">
         <textarea
-          class="border-0 outline-0 w-full p-3 text-base text-gray-400 h-full hover:ring-4 focus:ring-2 bg-transparent transition-primary"
+          class="border-0 outline-0 w-full p-3 text-base text-gray-400 h-full hover:ring-4 focus:ring-2 bg-transparent transition-primary resize-none "
           placeholder="Enter Your Text"
           v-model="model.from"
         />
@@ -100,7 +100,7 @@
       <!-- card to -->
       <div class="w-1/2">
         <textarea
-          class="border-0 outline-0 w-full p-3 text-gray-400 h-full hover:ring-4 focus:ring-2 bg-transparent transition-primary"
+          class="border-0 outline-0 w-full p-3 text-gray-400 h-full hover:ring-4 focus:ring-2 bg-transparent transition-primary resize-none "
           v-model="model.to"
           readonly
         />


### PR DESCRIPTION
BEFORE
https://cdn.discordapp.com/attachments/883602591089573898/1076457449332150282/image.png
AFTER
https://media.discordapp.net/attachments/883602591089573898/1076457544748384316/image.png
